### PR TITLE
[STEP12] Redisson 분산 락 적용

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ HELP.md
 build/
 data/
 logs/
+grafana/
+init/
 le/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/
 !**/src/test/**/build/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM openjdk:17
+ARG JAR_FILE=/build/libs/server-fd79c83.jar
+COPY ${JAR_FILE} /ecommerce.jar
+ENTRYPOINT ["java","-jar","/ecommerce.jar"]

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 패션 브랜드 플랫폼을 위한 E-Commerce 서버를 개발하고자 합니다 🙂
 
+[STEP11] 과제 링크: https://stealth-metal-dd1.notion.site/STEP11-1838778b3259805b948eeeaa0b4f564b?pvs=4
+
 ----
 
 ## Business Requirements

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,6 +40,11 @@ dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-data-jpa")
 	implementation("org.springframework.boot:spring-boot-starter-web")
 	implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2")
+	implementation("org.redisson:redisson-spring-boot-starter:3.18.0")
+
+	// Monitoring
+	implementation("org.springframework.boot:spring-boot-starter-actuator")
+	implementation("io.micrometer:micrometer-registry-prometheus")
 
 	// Lombok
 	compileOnly("org.projectlombok:lombok")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,16 +1,98 @@
 version: '3'
 services:
+  spring:
+    container_name: spring
+    deploy:
+      resources:
+        limits:
+          cpus: '4.0'
+          memory: 2048M
+        reservations:
+          cpus: '4.0'
+          memory: 2048M
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "8080:8080"
+    environment:
+      - SPRING_DATASOURCE_URL=jdbc:mysql://mysql:3306/hhplus?characterEncoding=UTF-8&serverTimezone=UTC
+      - SPRING_DATASOURCE_USERNAME=application
+      - SPRING_DATASOURCE_PASSWORD=application
+    depends_on:
+      - mysql
+      - redis
+
   mysql:
     image: mysql:8.0
+    container_name: mysql
+    deploy:
+      resources:
+        limits:
+          cpus: '2.0'
+          memory: 2048M
+        reservations:
+          cpus: '2.0'
+          memory: 2048M
     ports:
       - "3306:3306"
+    restart: always
     environment:
-      - MYSQL_ROOT_PASSWORD=root
+      - MYSQL_ROOT_PASSWORD=password
       - MYSQL_USER=application
       - MYSQL_PASSWORD=application
       - MYSQL_DATABASE=hhplus
     volumes:
       - ./data/mysql/:/var/lib/mysql
+      - ./init/:/docker-entrypoint-initdb.d
+
+  mysql-exporter:
+    container_name: mysql-exporter
+    image: prom/mysqld-exporter
+    command:
+      - "--mysqld.username=application:application"
+      - "--mysqld.address=mysql:3306"
+    ports:
+      - "9104:9104"
+    depends_on:
+      - mysql
+
+  redis:
+    image: redis:latest
+    container_name: redis
+    ports:
+      - "6379:6379"
+
+  k6:
+    image: grafana/k6:latest
+    container_name: k6
+    ports:
+      - "6565:6565"
+    volumes:
+      - ./script.js:/script.js
+    command: run /script.js
+    network_mode: host
+
+  grafana:
+    image: grafana/grafana
+    container_name: grafana
+    volumes:
+      - ./grafana:/var/lib/grafana
+    ports:
+      - "3000:3000"
+    restart: always
+    depends_on:
+      - prometheus
+    privileged: true
+
+  prometheus:
+    image: prom/prometheus
+    container_name: prometheus
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+    ports:
+      - "9090:9090"
+    restart: always
 
 networks:
   default:

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -1,0 +1,18 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: "prometheus"
+    static_configs:
+      - targets: ["localhost:9090"]
+
+  - job_name: "mysqld-exporter"
+    static_configs:
+      - targets: ["host.docker.internal:9104"]
+
+  - job_name: "java_application"
+    metrics_path: '/actuator/prometheus'
+    scrape_interval: 5s
+    static_configs:
+      - targets: ["host.docker.internal:8080"]

--- a/script.js
+++ b/script.js
@@ -1,0 +1,36 @@
+import http from 'k6/http';
+import { check } from 'k6';
+
+export const options = {
+    batchPerHost: 10,
+    scenarios: {
+        coupon_scenario: {
+            vus: 1000,
+            // exec: 'coupon_scenario',
+            executor: 'per-vu-iterations',
+            iterations: 1
+        }
+    }
+};
+
+export default function () {
+    const body = JSON.stringify({
+        couponId: 1
+    });
+
+    // HTTP POST 요청 설정
+    const params = {
+        headers: {
+            'Authorization': `Bearer ${__VU}`,
+            'Content-Type': 'application/json',
+        },
+    };
+
+    // POST 요청 보내기
+    let response = http.post('http://localhost:8080/v1/coupons', body, params);
+
+    // 응답 확인
+    check(response, {
+        'is status 200': (r) => r.status === 200,
+    });
+}

--- a/src/main/java/kr/hhplus/be/server/aop/DistributedLockAop.java
+++ b/src/main/java/kr/hhplus/be/server/aop/DistributedLockAop.java
@@ -1,0 +1,60 @@
+package kr.hhplus.be.server.aop;
+
+import kr.hhplus.be.server.infra.lock.DistributedLock;
+import kr.hhplus.be.server.infra.lock.LockManager;
+import lombok.RequiredArgsConstructor;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.redisson.api.RLock;
+import org.springframework.expression.ExpressionParser;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.expression.spel.support.StandardEvaluationContext;
+import org.springframework.stereotype.Component;
+
+import java.lang.reflect.Method;
+
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class DistributedLockAop {
+    private static final String REDISSON_LOCK_PREFIX = "LOCK:";
+
+    private final LockManager lockManager;
+    private final StandaloneTransactionAop standaloneTransactionAop;
+
+    @Around("@annotation(kr.hhplus.be.server.infra.lock.DistributedLock)")
+    public Object lock(final ProceedingJoinPoint joinPoint) throws Throwable {
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+        Method method = signature.getMethod();
+        DistributedLock distributedLock = method.getAnnotation(DistributedLock.class);
+
+        String key = REDISSON_LOCK_PREFIX + getDynamicValue(signature.getParameterNames(), joinPoint.getArgs(), distributedLock.key());
+        RLock lock = lockManager.getLock(key);
+        try {
+            boolean available = lockManager.tryLock(key, distributedLock.waitTime(), distributedLock.leaseTime(), distributedLock.timeUnit());
+            if (!available) {
+                return false;
+            }
+            return standaloneTransactionAop.proceed(joinPoint);
+        } catch (InterruptedException e) {
+            throw new InterruptedException();
+        } finally {
+            if (lock.isLocked() && lock.isHeldByCurrentThread()) {
+                lockManager.unlock(key);
+            }
+        }
+    }
+
+    private Object getDynamicValue(String[] parameterNames, Object[] args, String key) {
+        ExpressionParser parser = new SpelExpressionParser();
+        StandardEvaluationContext context = new StandardEvaluationContext();
+
+        for (int i = 0; i < parameterNames.length; i++) {
+            context.setVariable(parameterNames[i], args[i]);
+        }
+
+        return parser.parseExpression(key).getValue(context, Object.class);
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/aop/StandaloneTransactionAop.java
+++ b/src/main/java/kr/hhplus/be/server/aop/StandaloneTransactionAop.java
@@ -1,0 +1,15 @@
+package kr.hhplus.be.server.aop;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+public class StandaloneTransactionAop {
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public Object proceed(final ProceedingJoinPoint joinPoint) throws Throwable {
+        return joinPoint.proceed();
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/config/redis/RedissonConfig.java
+++ b/src/main/java/kr/hhplus/be/server/config/redis/RedissonConfig.java
@@ -1,0 +1,29 @@
+package kr.hhplus.be.server.config.redis;
+
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RedissonConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String redisHost;
+
+    @Value("${spring.data.redis.port}")
+    private int redisPort;
+
+    private static final String REDISSON_HOST_PREFIX = "redis://";
+
+    @Bean
+    public RedissonClient redissonClient() {
+        RedissonClient redisson = null;
+        Config config = new Config();
+        config.useSingleServer().setAddress(REDISSON_HOST_PREFIX + redisHost + ":" + redisPort);
+        redisson = Redisson.create(config);
+        return redisson;
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/domain/coupon/facade/CouponFacade.java
+++ b/src/main/java/kr/hhplus/be/server/domain/coupon/facade/CouponFacade.java
@@ -31,7 +31,6 @@ public class CouponFacade {
                 .collect(Collectors.toList());
     }
 
-    @Transactional
     public CouponResponse issue(User user, CouponIssueRequest request) {
         Coupon coupon = couponService.issue(user, request.couponId());
         return new CouponResponse(coupon.getId(), coupon.getCode(), coupon.getStartDate(), coupon.getEndDate());

--- a/src/main/java/kr/hhplus/be/server/domain/coupon/repository/CouponCoreRepository.java
+++ b/src/main/java/kr/hhplus/be/server/domain/coupon/repository/CouponCoreRepository.java
@@ -12,6 +12,11 @@ public class CouponCoreRepository implements CouponRepository {
     private final CouponJpaRepository jpaRepository;
 
     @Override
+    public Coupon findById(Long id) {
+        return jpaRepository.findById(id).orElseThrow(CouponNotFoundException::new);
+    }
+
+    @Override
     public Coupon findByIdWithLock(Long id) {
         return jpaRepository.findByIdWithLock(id).orElseThrow(CouponNotFoundException::new);
     }

--- a/src/main/java/kr/hhplus/be/server/domain/coupon/repository/CouponRepository.java
+++ b/src/main/java/kr/hhplus/be/server/domain/coupon/repository/CouponRepository.java
@@ -4,6 +4,8 @@ import kr.hhplus.be.server.domain.coupon.domain.Coupon;
 
 public interface CouponRepository {
 
+    Coupon findById(Long id);
+
     Coupon findByIdWithLock(Long id);
 
     Coupon save(Coupon coupon);

--- a/src/main/java/kr/hhplus/be/server/infra/lock/DistributedLock.java
+++ b/src/main/java/kr/hhplus/be/server/infra/lock/DistributedLock.java
@@ -1,0 +1,20 @@
+package kr.hhplus.be.server.infra.lock;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.concurrent.TimeUnit;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface DistributedLock {
+
+    String key();
+
+    TimeUnit timeUnit() default TimeUnit.SECONDS;
+
+    long waitTime() default 5L;
+
+    long leaseTime() default 5L;
+}

--- a/src/main/java/kr/hhplus/be/server/infra/lock/LockManager.java
+++ b/src/main/java/kr/hhplus/be/server/infra/lock/LockManager.java
@@ -1,0 +1,14 @@
+package kr.hhplus.be.server.infra.lock;
+
+import org.redisson.api.RLock;
+
+import java.util.concurrent.TimeUnit;
+
+public interface LockManager {
+
+    RLock getLock(String key);
+
+    boolean tryLock(String key, long waitTime, long leaseTime, TimeUnit timeUnit) throws InterruptedException;
+
+    void unlock(String key);
+}

--- a/src/main/java/kr/hhplus/be/server/infra/lock/redis/RedissonLockManager.java
+++ b/src/main/java/kr/hhplus/be/server/infra/lock/redis/RedissonLockManager.java
@@ -1,0 +1,33 @@
+package kr.hhplus.be.server.infra.lock.redis;
+
+import kr.hhplus.be.server.infra.lock.LockManager;
+import lombok.RequiredArgsConstructor;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.TimeUnit;
+
+@Component
+@RequiredArgsConstructor
+public class RedissonLockManager implements LockManager {
+
+    private final RedissonClient redissonClient;
+
+    @Override
+    public RLock getLock(String key) {
+        return redissonClient.getLock(key);
+    }
+
+    @Override
+    public boolean tryLock(String key, long waitTime, long leaseTime, TimeUnit timeUnit) throws InterruptedException {
+        RLock rLock = redissonClient.getLock(key);
+        return rLock.tryLock(waitTime, leaseTime, timeUnit);
+    }
+
+    @Override
+    public void unlock(String key) {
+        RLock rLock = redissonClient.getLock(key);
+        rLock.unlock();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -14,7 +14,7 @@ spring:
       connection-timeout: 10000
       max-lifetime: 60000
     driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://localhost:3306/hhplus?characterEncoding=UTF-8&serverTimezone=UTC
+    url: jdbc:mysql://mysql:3306/hhplus?characterEncoding=UTF-8&serverTimezone=UTC
     username: application
     password: application
   jpa:
@@ -26,9 +26,20 @@ spring:
     properties:
       hibernate.timezone.default_storage: NORMALIZE_UTC
       hibernate.jdbc.time_zone: UTC
+      hibernate.dialect: org.hibernate.dialect.MySQL8Dialect
   web:
     resources:
       static-locations: classpath:/
+  data:
+    redis:
+      host: redis
+      port: 6379
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: prometheus
 
 springdoc:
   swagger-ui:

--- a/src/test/java/kr/hhplus/be/server/TestcontainersConfiguration.java
+++ b/src/test/java/kr/hhplus/be/server/TestcontainersConfiguration.java
@@ -1,10 +1,8 @@
 package kr.hhplus.be.server;
 
 import jakarta.annotation.PreDestroy;
-import org.springframework.boot.test.context.TestConfiguration;
-import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.MySQLContainer;
 import org.testcontainers.utility.DockerImageName;
 
@@ -12,6 +10,7 @@ import org.testcontainers.utility.DockerImageName;
 class TestcontainersConfiguration {
 
 	public static final MySQLContainer<?> MYSQL_CONTAINER;
+	public static final GenericContainer<?> REDIS_CONTAINER;
 
 	static {
 		MYSQL_CONTAINER = new MySQLContainer<>(DockerImageName.parse("mysql:8.0"))
@@ -24,12 +23,24 @@ class TestcontainersConfiguration {
 		System.setProperty("spring.datasource.url", MYSQL_CONTAINER.getJdbcUrl() + "?characterEncoding=UTF-8&serverTimezone=UTC");
 		System.setProperty("spring.datasource.username", MYSQL_CONTAINER.getUsername());
 		System.setProperty("spring.datasource.password", MYSQL_CONTAINER.getPassword());
+
+		int redisPort = 6379;
+		REDIS_CONTAINER = new GenericContainer<>(DockerImageName.parse("redis:latest"))
+				.withExposedPorts(redisPort);
+		REDIS_CONTAINER.start();
+
+		System.setProperty("spring.data.redis.host", REDIS_CONTAINER.getHost());
+		System.setProperty("spring.data.redis.port", REDIS_CONTAINER.getMappedPort(redisPort).toString());
 	}
 
 	@PreDestroy
 	public void preDestroy() {
 		if (MYSQL_CONTAINER.isRunning()) {
 			MYSQL_CONTAINER.stop();
+		}
+
+		if (REDIS_CONTAINER.isRunning()) {
+			REDIS_CONTAINER.stop();
 		}
 	}
 }

--- a/src/test/java/kr/hhplus/be/server/unit/domain/coupon/service/CouponServiceTest.java
+++ b/src/test/java/kr/hhplus/be/server/unit/domain/coupon/service/CouponServiceTest.java
@@ -77,7 +77,7 @@ class CouponServiceTest {
         Coupon coupon = CouponFixture.create(1L, CouponDiscountType.RATE, 10, startDate, endDate, 10);
         UserCoupon userCoupon = new UserCoupon(user, coupon);
         
-        when(couponCoreRepository.findByIdWithLock(coupon.getId())).thenReturn(coupon);
+        when(couponCoreRepository.findById(coupon.getId())).thenReturn(coupon);
         when(userCouponCoreRepository.existsByUserAndCoupon(user, coupon)).thenReturn(false);
         when(userCouponCoreRepository.save(userCoupon)).thenReturn(userCoupon);
         when(couponCoreRepository.save(coupon)).thenReturn(coupon);
@@ -88,7 +88,7 @@ class CouponServiceTest {
         // then
         assertThat(issuedCoupon.getIssuedCount()).isEqualTo(1);
 
-        verify(couponCoreRepository, times(1)).findByIdWithLock(coupon.getId());
+        verify(couponCoreRepository, times(1)).findById(coupon.getId());
         verify(userCouponCoreRepository, times(1)).existsByUserAndCoupon(user, coupon);
         verify(userCouponCoreRepository, times(1)).save(userCoupon);
         verify(couponCoreRepository, times(1)).save(coupon);
@@ -103,7 +103,7 @@ class CouponServiceTest {
         LocalDateTime endDate = startDate.plusWeeks(1);
         Coupon coupon = CouponFixture.create(1L, CouponDiscountType.RATE, 10, startDate, endDate, 0);
 
-        when(couponCoreRepository.findByIdWithLock(coupon.getId())).thenReturn(coupon);
+        when(couponCoreRepository.findById(coupon.getId())).thenReturn(coupon);
 
         // when & then
         assertThatThrownBy(() -> couponService.issue(user, coupon.getId()))
@@ -119,7 +119,7 @@ class CouponServiceTest {
         LocalDateTime endDate = startDate.plusWeeks(1);
         Coupon coupon = CouponFixture.create(1L, CouponDiscountType.RATE, 10, startDate, endDate, 10);
 
-        when(couponCoreRepository.findByIdWithLock(coupon.getId())).thenReturn(coupon);
+        when(couponCoreRepository.findById(coupon.getId())).thenReturn(coupon);
         when(userCouponCoreRepository.existsByUserAndCoupon(user, coupon)).thenReturn(true);
 
         // when & then


### PR DESCRIPTION
## PR 설명
<!-- 해당 PR이 왜 발생했고, 어떤부분에 대한 작업인지 작성해주세요. -->

> [STEP-12] Requirements
> - DB Lock 을 활용한 동시성 제어 방식 에서 해당 비즈니스 로직에서 적합하다고 판단하여 차용한 동시성 제어 방식을 구현하여 비즈니스 로직에 적용하고, 통합테스트 등으로 이를 검증하는 코드 작성 및 제출

위 요구사항에 따라 다음과 같은 세부 작업이 포함되어 있습니다.

- [x] 쿠폰 발급 Redisson 분산 락 적용

## 리뷰 포인트
<!-- 
    리뷰어가 함께 고민해주었으면 하는 내용을 간략하게 기재해주세요.
    커밋 링크가 포함되면, 더욱이 효과적일 거예요! 
-->

1. (질문)
- 결제 유즈 케이스에 분산 락을 적용한다고 했을 때 상품 재고 차감 트랜잭션이 커밋된 뒤 포인트 잔액부족으로 예외 발생해서 결과적으로 재고를 복원해야 하는 경우를 어떻게 처리할지 고민이 됐습니다. 
- 가장 간단한 구조는 Facade 쪽에서 결제 서비스에서 예외 발생 시 재고 부분을 채워 넣는 방식이 있는 것 같은데 이 부분 어떻게 처리하면 좋을지 한 번 의견을 여쭤보고 싶습니다.

2. (고민) 
- Redis 분산 락 적용으로 바꾼 뒤 K6 통해 쿠폰 발급 상황을 테스트 해봤습니다. 동시에 1000명 요청을 하는 상황이었고, 몇 몇 요청은 처리되는데, 대부분은 DB 커넥션을 얻지 못해서 데드락이 자주 발생하는 상황이었습니다. (HikariCP maximum-pool-size이 3으로 설정되어 있는데 이를 디폴트 값인 10으로 올려도 비슷한 결과) 

- 레디스 분산 락 이용시 락 획득 이후 트랜잭션 시작, 트랜잭션 커밋 이후 락 반환 이 순서를 지키기 위해 분산 락 적용된 서비스에 @Transactional(propagation = Propagation.REQUIRES_NEW) 설정한 부분이 주요 원인으로 보이는데, 혹시 이게 원인이 맞다면 Propagation.REQUIRES_NEW를 사용하는 게 적절하지 않을수도 있을 것 같습니다.
  
- 락 획득 이후 트랜잭션 시작, 트랜잭션 커밋 이후 락 반환 <- 이 순서를 보장하는 선에서 다른 트랜잭션 전파 옵션을 통해 문제를 풀 수 있는지를 한 번 알아보려고 합니다. 