### PR TITLE
[STEP14] Redis 기반의 선착순 쿠폰 발급 기능 구현

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -36,7 +36,6 @@ dependencyManagement {
 
 dependencies {
     // Spring
-	implementation("org.springframework.boot:spring-boot-starter-actuator")
 	implementation("org.springframework.boot:spring-boot-starter-data-jpa")
 	implementation("org.springframework.boot:spring-boot-starter-web")
 	implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2")
@@ -65,6 +64,7 @@ dependencies {
 	testImplementation("org.testcontainers:mysql")
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 	testImplementation("io.rest-assured:rest-assured:5.3.1")
+	testImplementation("org.awaitility:awaitility:4.2.0")
 
 	// Docs
 	configurations["asciidoctorExt"]("org.springframework.restdocs:spring-restdocs-asciidoctor")

--- a/src/main/java/kr/hhplus/be/server/api/coupon/application/CouponFacade.java
+++ b/src/main/java/kr/hhplus/be/server/api/coupon/application/CouponFacade.java
@@ -1,9 +1,10 @@
 package kr.hhplus.be.server.api.coupon.application;
 
 import kr.hhplus.be.server.api.coupon.application.dto.AvailableCouponsResult;
-import kr.hhplus.be.server.api.coupon.application.dto.IssueCouponResult;
 import kr.hhplus.be.server.domain.coupon.model.Coupon;
+import kr.hhplus.be.server.domain.coupon.service.CouponIssueManager;
 import kr.hhplus.be.server.domain.coupon.service.CouponService;
+import kr.hhplus.be.server.domain.coupon.service.dto.CouponIssueParam;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -16,6 +17,7 @@ import java.util.List;
 public class CouponFacade {
 
     private final CouponService couponService;
+    private final CouponIssueManager couponIssueRequestManager;
 
     @Transactional(readOnly = true)
     public AvailableCouponsResult findAvailableCoupons(long userId, Pageable pageable) {
@@ -23,9 +25,7 @@ public class CouponFacade {
         return AvailableCouponsResult.from(coupons);
     }
 
-    @Transactional
-    public IssueCouponResult issue(long userId, Long couponId) {
-        Coupon coupon = couponService.issue(userId, couponId);
-        return IssueCouponResult.from(coupon);
+    public void sendCouponIssueRequest(long userId, Long couponId) {
+        couponIssueRequestManager.publish(new CouponIssueParam(userId, couponId));
     }
 }

--- a/src/main/java/kr/hhplus/be/server/api/coupon/controller/CouponController.java
+++ b/src/main/java/kr/hhplus/be/server/api/coupon/controller/CouponController.java
@@ -1,14 +1,13 @@
 package kr.hhplus.be.server.api.coupon.controller;
 
 import kr.hhplus.be.server.api.coupon.application.dto.AvailableCouponsResult;
-import kr.hhplus.be.server.api.coupon.application.dto.IssueCouponResult;
 import kr.hhplus.be.server.api.coupon.controller.dto.request.IssueCouponRequest;
 import kr.hhplus.be.server.api.coupon.controller.dto.response.AvailableCouponsResponse;
-import kr.hhplus.be.server.api.coupon.controller.dto.response.IssueCouponResponse;
 import kr.hhplus.be.server.api.coupon.application.CouponFacade;
 import kr.hhplus.be.server.domain.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -26,8 +25,8 @@ public class CouponController {
     }
 
     @PostMapping
-    public ResponseEntity<IssueCouponResponse> issueCoupon(User user, @RequestBody IssueCouponRequest request) {
-        IssueCouponResult result = couponFacade.issue(user.getId(), request.couponId());
-        return ResponseEntity.ok(IssueCouponResponse.from(result));
+    public ResponseEntity<Void> issueCoupon(User user, @RequestBody IssueCouponRequest request) {
+        couponFacade.sendCouponIssueRequest(user.getId(), request.couponId());
+        return ResponseEntity.status(HttpStatus.ACCEPTED).build();
     }
 }

--- a/src/main/java/kr/hhplus/be/server/domain/coupon/service/CouponIssueManager.java
+++ b/src/main/java/kr/hhplus/be/server/domain/coupon/service/CouponIssueManager.java
@@ -1,0 +1,48 @@
+package kr.hhplus.be.server.domain.coupon.service;
+
+import kr.hhplus.be.server.domain.coupon.service.dto.CouponIssueParam;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Component
+@RequiredArgsConstructor
+public class CouponIssueManager {
+
+    private static final String COUPON_ISSUE_QUEUE_KEY = "coupon_issue_queue";
+    private static final String ISSUED_COUPONS_KEY = "issued_coupons";
+
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    public void publish(CouponIssueParam param) {
+        redisTemplate.opsForZSet().add(COUPON_ISSUE_QUEUE_KEY, param, Instant.now().toEpochMilli());
+    }
+
+    public List<CouponIssueParam> consume(int batch) {
+        Set<Object> requests = redisTemplate.opsForZSet().range(COUPON_ISSUE_QUEUE_KEY, 0, batch - 1);
+        if (requests == null || requests.isEmpty()) {
+            return Collections.emptyList();
+        }
+        return requests.stream()
+                .map(request -> (CouponIssueParam) request)
+                .collect(Collectors.toList());
+    }
+
+    public boolean validateAlreadyIssued(CouponIssueParam param) {
+        return Boolean.TRUE.equals(redisTemplate.opsForSet().isMember(ISSUED_COUPONS_KEY, param));
+    }
+
+    public void markCouponAsIssued(CouponIssueParam param) {
+        redisTemplate.opsForSet().add(ISSUED_COUPONS_KEY, param);
+    }
+
+    public void removeCouponRequest(CouponIssueParam param) {
+        redisTemplate.opsForZSet().remove(COUPON_ISSUE_QUEUE_KEY, param);
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/domain/coupon/service/CouponService.java
+++ b/src/main/java/kr/hhplus/be/server/domain/coupon/service/CouponService.java
@@ -26,7 +26,7 @@ public class CouponService {
 
     @Transactional
     public Coupon issue(long userId, long couponId) {
-        Coupon coupon = couponRepository.findByIdWithLock(couponId);
+        Coupon coupon = couponRepository.findById(couponId);
         coupon.issue();
         if (issuedCouponRepository.existsByUserIdAndCoupon(userId, coupon)) {
             throw new AlreadyIssuedCouponException();

--- a/src/main/java/kr/hhplus/be/server/domain/coupon/service/dto/CouponIssueParam.java
+++ b/src/main/java/kr/hhplus/be/server/domain/coupon/service/dto/CouponIssueParam.java
@@ -1,0 +1,7 @@
+package kr.hhplus.be.server.domain.coupon.service.dto;
+
+public record CouponIssueParam(
+        Long userId,
+        Long couponId
+) {
+}

--- a/src/main/java/kr/hhplus/be/server/domain/support/cache/aop/ProductCacheAspect.java
+++ b/src/main/java/kr/hhplus/be/server/domain/support/cache/aop/ProductCacheAspect.java
@@ -26,7 +26,6 @@ public class ProductCacheAspect {
         Pageable pageable = (Pageable) joinPoint.getArgs()[0];
         Object cachedProducts = productCacheManager.fetchSellableProducts(pageable);
         if (!((List<?>) cachedProducts).isEmpty()) {
-            System.out.println("캐시 리턴");
             return cachedProducts;
         }
 

--- a/src/main/java/kr/hhplus/be/server/infra/redis/config/RedisTemplateClientConfig.java
+++ b/src/main/java/kr/hhplus/be/server/infra/redis/config/RedisTemplateClientConfig.java
@@ -1,4 +1,4 @@
-package kr.hhplus.be.server.infra.cache.config;
+package kr.hhplus.be.server.infra.redis.config;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cache.annotation.EnableCaching;
@@ -12,7 +12,7 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
 @EnableCaching
-public class RedisCacheConfig {
+public class RedisTemplateClientConfig {
 
     @Value("${spring.data.redis.host}")
     private String host;

--- a/src/main/java/kr/hhplus/be/server/scheduler/config/SchedulerConfig.java
+++ b/src/main/java/kr/hhplus/be/server/scheduler/config/SchedulerConfig.java
@@ -1,0 +1,9 @@
+package kr.hhplus.be.server.scheduler.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+public class SchedulerConfig {
+}

--- a/src/main/java/kr/hhplus/be/server/scheduler/coupon/CouponScheduler.java
+++ b/src/main/java/kr/hhplus/be/server/scheduler/coupon/CouponScheduler.java
@@ -1,0 +1,34 @@
+package kr.hhplus.be.server.scheduler.coupon;
+
+import kr.hhplus.be.server.domain.coupon.service.CouponIssueManager;
+import kr.hhplus.be.server.domain.coupon.service.CouponService;
+import kr.hhplus.be.server.domain.coupon.service.dto.CouponIssueParam;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class CouponScheduler {
+
+    private final CouponService couponService;
+    private final CouponIssueManager couponIssueManager;
+
+    @Value("${schedules.batch.coupon-issue-size}")
+    private int couponIssueBatchSize;
+
+    @Scheduled(cron = "${schedules.cron.coupon.issue}")
+    public void issueCouponScheduler() {
+        List<CouponIssueParam> params = couponIssueManager.consume(couponIssueBatchSize);
+        for (CouponIssueParam param : params) {
+            if (!couponIssueManager.validateAlreadyIssued(param)) {
+                couponService.issue(param.userId(), param.couponId());
+                couponIssueManager.markCouponAsIssued(param);
+            }
+            couponIssueManager.removeCouponRequest(param);
+        }
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -46,3 +46,10 @@ springdoc:
     urls:
       - name: E-Commerce API
         url: openapi.yml
+
+schedules:
+  cron:
+    coupon:
+      issue: "*/5 * * * * *"
+  batch:
+    coupon-issue-size: 10

--- a/src/test/java/kr/hhplus/be/server/api/coupon/application/CouponFacadeTest.java
+++ b/src/test/java/kr/hhplus/be/server/api/coupon/application/CouponFacadeTest.java
@@ -1,18 +1,17 @@
 package kr.hhplus.be.server.api.coupon.application;
 
 import kr.hhplus.be.server.api.coupon.application.dto.AvailableCouponsResult;
-import kr.hhplus.be.server.api.coupon.application.dto.IssueCouponResult;
 import kr.hhplus.be.server.domain.coupon.model.Coupon;
 import kr.hhplus.be.server.domain.coupon.model.CouponDiscountType;
-import kr.hhplus.be.server.domain.coupon.exception.AlreadyIssuedCouponException;
-import kr.hhplus.be.server.domain.coupon.exception.MaxIssuableCountExceededException;
 import kr.hhplus.be.server.domain.coupon.repository.CouponRepository;
 import kr.hhplus.be.server.domain.coupon.service.CouponService;
 import kr.hhplus.be.server.domain.user.domain.User;
 import kr.hhplus.be.server.domain.user.repository.UserRepository;
+import kr.hhplus.be.server.infra.storage.core.jpa.repository.IssuedCouponJpaRepository;
 import kr.hhplus.be.server.util.ServiceTest;
 import kr.hhplus.be.server.util.fixture.CouponFixture;
 import kr.hhplus.be.server.util.fixture.UserFixture;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -20,9 +19,16 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @DisplayName("쿠폰 Facade 통합 테스트")
 class CouponFacadeTest extends ServiceTest {
@@ -32,6 +38,9 @@ class CouponFacadeTest extends ServiceTest {
 
     @Autowired
     private CouponRepository couponRepository;
+
+    @Autowired
+    private IssuedCouponJpaRepository issuedCouponJpaRepository;
 
     @Autowired
     private CouponService couponService;
@@ -58,52 +67,63 @@ class CouponFacadeTest extends ServiceTest {
         assertThat(result.coupons()).hasSize(1);
     }
 
-    @DisplayName("유저에게 쿠폰을 발급한다.")
+    /**
+     * 20명이 동시에 쿠폰 발급을 시도하고, 모든 쿠폰이 발급된 경우 예외 발생을 검증하는 테스트입니다. (성공: 10명, 실패: 10명)
+     */
+    @DisplayName("최대 발급 수량이 10개인 쿠폰을 20명의 서로 다른 유저가 쿠폰 발급을 신청할 때, 10개의 쿠폰이 모두 발급된 경우 나머지 10명은 쿠폰 발급에 실패한다.")
     @Test
-    void issue() {
+    void sendCouponIssueRequestConcurrently_exceededMaxIssuableCount() throws InterruptedException {
         // given
-        User user = userRepository.save(UserFixture.USER());
-
         LocalDateTime startDate = LocalDateTime.now();
         LocalDateTime endDate = startDate.plusWeeks(1);
         Coupon coupon = couponRepository.save(CouponFixture.create(CouponDiscountType.RATE, 10, startDate, endDate, 10));
+
+        int threads = 20;
+        AtomicInteger successCount = new AtomicInteger(0);
+        AtomicInteger failCount = new AtomicInteger(0);
+
+        List<User> users = new ArrayList<>();
+        for (int i = 1; i <= 20; i++) {
+            users.add(userRepository.save(UserFixture.USER()));
+        }
 
         // when
-        IssueCouponResult result = couponFacade.issue(user.getId(), coupon.getId());
+        executeConcurrency(threads, idx -> {
+            try {
+                couponFacade.sendCouponIssueRequest(users.get(idx).getId(), coupon.getId());
+                successCount.incrementAndGet();
+            } catch (Exception e) {
+                failCount.incrementAndGet();
+            }
+        });
 
         // then
-        assertThat(result.couponId()).isEqualTo(coupon.getId());
-        assertThat(result.code()).isEqualTo(coupon.getCode());
+        assertThat(successCount.get()).isEqualTo(20);
+        assertThat(failCount.get()).isZero();
+
+        Awaitility
+                .await()
+                .atMost(5, TimeUnit.SECONDS)
+                .pollInterval(1, TimeUnit.SECONDS)
+                .untilAsserted(() -> assertThat(issuedCouponJpaRepository.count()).isEqualTo(10));
     }
 
-    @DisplayName("쿠폰 발급 시, 발급 가능 수량을 초과한 경우 예외가 발생한다.")
-    @Test
-    void issue_exceededMaxIssuableCount() {
-        // given
-        User user = userRepository.save(UserFixture.USER());
+    private void executeConcurrency(int threads, Consumer<Integer> task) throws InterruptedException {
+        CountDownLatch latch = new CountDownLatch(threads);
+        ExecutorService executor = Executors.newFixedThreadPool(threads);
 
-        LocalDateTime startDate = LocalDateTime.now();
-        LocalDateTime endDate = startDate.plusWeeks(1);
-        Coupon coupon = couponRepository.save(CouponFixture.create(CouponDiscountType.RATE, 10, startDate, endDate, 0));
+        for (int i = 0; i < threads; i++) {
+            int idx = i;
+            executor.execute(() -> {
+                try {
+                    task.accept(idx);
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
 
-        // when & then
-        assertThatThrownBy(() -> couponFacade.issue(user.getId(), coupon.getId()))
-                .isInstanceOf(MaxIssuableCountExceededException.class);
-    }
-
-    @DisplayName("쿠폰 발급 시, 이미 유저에게 쿠폰 발급 이력이 있는 경우 예외가 발생한다.")
-    @Test
-    void issue_alreadyIssuedCoupon() {
-        // given
-        User user = userRepository.save(UserFixture.USER());
-
-        LocalDateTime startDate = LocalDateTime.now();
-        LocalDateTime endDate = startDate.plusWeeks(1);
-        Coupon coupon = couponRepository.save(CouponFixture.create(CouponDiscountType.RATE, 10, startDate, endDate, 10));
-        couponFacade.issue(user.getId(), coupon.getId());
-
-        // when & then
-        assertThatThrownBy(() -> couponFacade.issue(user.getId(), coupon.getId()))
-                .isInstanceOf(AlreadyIssuedCouponException.class);
+        latch.await();
+        executor.shutdown();
     }
 }

--- a/src/test/java/kr/hhplus/be/server/domain/coupon/CouponServiceTest.java
+++ b/src/test/java/kr/hhplus/be/server/domain/coupon/CouponServiceTest.java
@@ -27,6 +27,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.*;
 
+@DisplayName("쿠폰 Service 단위 테스트")
 @ExtendWith(MockitoExtension.class)
 class CouponServiceTest {
     
@@ -76,7 +77,7 @@ class CouponServiceTest {
         Coupon coupon = CouponFixture.create(1L, CouponDiscountType.RATE, 10, startDate, endDate, 10);
         IssuedCoupon issuedCoupon = new IssuedCoupon(user.getId(), coupon);
         
-        when(couponCoreRepository.findByIdWithLock(coupon.getId())).thenReturn(coupon);
+        when(couponCoreRepository.findById(coupon.getId())).thenReturn(coupon);
         when(issuedCouponCoreRepository.existsByUserIdAndCoupon(user.getId(), coupon)).thenReturn(false);
         when(issuedCouponCoreRepository.save(issuedCoupon)).thenReturn(issuedCoupon);
         when(couponCoreRepository.save(coupon)).thenReturn(coupon);
@@ -87,7 +88,7 @@ class CouponServiceTest {
         // then
         assertThat(issuedCoupon1.getIssuedCount()).isEqualTo(1);
 
-        verify(couponCoreRepository, times(1)).findByIdWithLock(coupon.getId());
+        verify(couponCoreRepository, times(1)).findById(coupon.getId());
         verify(issuedCouponCoreRepository, times(1)).existsByUserIdAndCoupon(user.getId(), coupon);
         verify(issuedCouponCoreRepository, times(1)).save(issuedCoupon);
         verify(couponCoreRepository, times(1)).save(coupon);
@@ -102,7 +103,7 @@ class CouponServiceTest {
         LocalDateTime endDate = startDate.plusWeeks(1);
         Coupon coupon = CouponFixture.create(1L, CouponDiscountType.RATE, 10, startDate, endDate, 0);
 
-        when(couponCoreRepository.findByIdWithLock(coupon.getId())).thenReturn(coupon);
+        when(couponCoreRepository.findById(coupon.getId())).thenReturn(coupon);
 
         // when & then
         assertThatThrownBy(() -> couponService.issue(user.getId(), coupon.getId()))
@@ -118,7 +119,7 @@ class CouponServiceTest {
         LocalDateTime endDate = startDate.plusWeeks(1);
         Coupon coupon = CouponFixture.create(1L, CouponDiscountType.RATE, 10, startDate, endDate, 10);
 
-        when(couponCoreRepository.findByIdWithLock(coupon.getId())).thenReturn(coupon);
+        when(couponCoreRepository.findById(coupon.getId())).thenReturn(coupon);
         when(issuedCouponCoreRepository.existsByUserIdAndCoupon(user.getId(), coupon)).thenReturn(true);
 
         // when & then

--- a/src/test/java/kr/hhplus/be/server/domain/coupon/service/CouponIssueManagerIntegrationTest.java
+++ b/src/test/java/kr/hhplus/be/server/domain/coupon/service/CouponIssueManagerIntegrationTest.java
@@ -1,0 +1,118 @@
+package kr.hhplus.be.server.domain.coupon.service;
+
+import kr.hhplus.be.server.domain.coupon.service.dto.CouponIssueParam;
+import kr.hhplus.be.server.util.DatabaseCleaner;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
+import java.util.Objects;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("쿠폰 발급 Manager 통합 테스트")
+@ActiveProfiles("test")
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
+class CouponIssueManagerIntegrationTest {
+
+    private static final String COUPON_ISSUE_QUEUE_KEY = "coupon_issue_queue";
+    private static final String ISSUED_COUPONS_KEY = "issued_coupons";
+
+    @Autowired
+    private CouponIssueManager couponIssueManager;
+
+    @Autowired
+    private RedisTemplate<String, Object> redisTemplate;
+
+    @Autowired
+    private DatabaseCleaner databaseCleaner;
+
+    @BeforeEach
+    void setUp() {
+        databaseCleaner.execute();
+        Objects.requireNonNull(redisTemplate.getConnectionFactory()).getConnection().serverCommands().flushAll();
+    }
+
+    @DisplayName("쿠폰 발급 요청을 Redis ZSET 자료 구조에 추가한다.")
+    @Test
+    void publish() {
+        // given
+        CouponIssueParam param = new CouponIssueParam(1L, 1L);
+
+        // when
+        couponIssueManager.publish(param);
+
+        // then
+        assertThat(redisTemplate.opsForZSet().size(COUPON_ISSUE_QUEUE_KEY)).isOne();
+        assertThat(redisTemplate.opsForZSet().range(COUPON_ISSUE_QUEUE_KEY, 0, -1)).contains(param);
+    }
+
+    @DisplayName("Redis ZSET 자료 구조에서 쿠폰 발급 요청 목록을 배치 단위로 읽어온다.")
+    @Test
+    void consume() {
+        // given
+        int batch = 3;
+        CouponIssueParam param1 = new CouponIssueParam(1L, 1L);
+        CouponIssueParam param2 = new CouponIssueParam(2L, 1L);
+        CouponIssueParam param3 = new CouponIssueParam(3L, 1L);
+
+        couponIssueManager.publish(param1);
+        couponIssueManager.publish(param2);
+        couponIssueManager.publish(param3);
+
+        // when
+        List<CouponIssueParam> params = couponIssueManager.consume(batch);
+
+        // then
+        assertThat(params.size()).isEqualTo(batch);
+        assertThat(redisTemplate.opsForZSet().size(COUPON_ISSUE_QUEUE_KEY)).isEqualTo(batch);
+    }
+
+    @DisplayName("쿠폰 발급 요청이 처리된 경우, Redis SET 자료 구조에서 발급 처리 여부를 확인 할 수 있다.")
+    @Test
+    void validateAlreadyIssuedCoupon() {
+        // given
+        CouponIssueParam param = new CouponIssueParam(1L, 1L);
+        couponIssueManager.markCouponAsIssued(param);
+
+        // when
+        boolean result = couponIssueManager.validateAlreadyIssued(param);
+
+        // then
+        assertThat(result).isTrue();
+    }
+
+    @DisplayName("쿠폰 발급 성공 시, Redis SET 자료 구조에 발급 기록을 저장한다.")
+    @Test
+    void markCouponAsIssued() {
+        // given
+        CouponIssueParam param = new CouponIssueParam(1L, 1L);
+
+        // when
+        couponIssueManager.markCouponAsIssued(param);
+
+        // then
+        assertThat(redisTemplate.opsForSet().size(ISSUED_COUPONS_KEY)).isOne();
+        assertThat(redisTemplate.opsForSet().isMember(ISSUED_COUPONS_KEY, param)).isTrue();
+    }
+
+    @DisplayName("쿠폰 발급 성공 시, Redis ZSET 자료 구조에서 쿠폰 발급 요청을 제거한다.")
+    @Test
+    void removeCouponRequest() {
+        // given
+        CouponIssueParam param = new CouponIssueParam(1L, 1L);
+        couponIssueManager.publish(param);
+
+        // when
+        couponIssueManager.removeCouponRequest(param);
+
+        // then
+        assertThat(redisTemplate.opsForZSet().size(COUPON_ISSUE_QUEUE_KEY)).isZero();
+        assertThat(redisTemplate.opsForZSet().range(COUPON_ISSUE_QUEUE_KEY, 0, -1)).doesNotContain(param);
+    }
+}

--- a/src/test/java/kr/hhplus/be/server/domain/product/ProductServiceIntegrationTest.java
+++ b/src/test/java/kr/hhplus/be/server/domain/product/ProductServiceIntegrationTest.java
@@ -37,6 +37,7 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -76,7 +77,7 @@ class ProductServiceIntegrationTest extends ServiceTest {
 
     @BeforeEach
     void setUp() {
-        redisTemplate.getConnectionFactory().getConnection().flushAll();
+        Objects.requireNonNull(redisTemplate.getConnectionFactory()).getConnection().serverCommands().flushAll();
     }
 
     @DisplayName("ID 기반으로 상품을 조회한다.")

--- a/src/test/java/kr/hhplus/be/server/scheduler/coupon/CouponSchedulerIntegrationTest.java
+++ b/src/test/java/kr/hhplus/be/server/scheduler/coupon/CouponSchedulerIntegrationTest.java
@@ -1,0 +1,119 @@
+package kr.hhplus.be.server.scheduler.coupon;
+
+import kr.hhplus.be.server.domain.coupon.model.Coupon;
+import kr.hhplus.be.server.domain.coupon.model.CouponDiscountType;
+import kr.hhplus.be.server.domain.coupon.repository.CouponRepository;
+import kr.hhplus.be.server.domain.coupon.repository.IssuedCouponRepository;
+import kr.hhplus.be.server.domain.coupon.service.CouponIssueManager;
+import kr.hhplus.be.server.domain.coupon.service.dto.CouponIssueParam;
+import kr.hhplus.be.server.domain.user.domain.User;
+import kr.hhplus.be.server.domain.user.repository.UserRepository;
+import kr.hhplus.be.server.util.DatabaseCleaner;
+import kr.hhplus.be.server.util.fixture.CouponFixture;
+import kr.hhplus.be.server.util.fixture.UserFixture;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.LocalDateTime;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.hamcrest.Matchers.equalTo;
+
+@DisplayName("쿠폰 발급 Scheduler 통합 테스트")
+@ActiveProfiles("test")
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
+class CouponSchedulerIntegrationTest {
+
+    private static final String COUPON_ISSUE_QUEUE_KEY = "coupon_issue_queue";
+    private static final String ISSUED_COUPONS_KEY = "issued_coupons";
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private CouponRepository couponRepository;
+
+    @Autowired
+    private IssuedCouponRepository issuedCouponRepository;
+
+    @Autowired
+    private CouponIssueManager couponIssueManager;
+
+    @Autowired
+    private RedisTemplate<String, Object> redisTemplate;
+
+    @Autowired
+    private DatabaseCleaner databaseCleaner;
+
+    @BeforeEach
+    void setUp() {
+        databaseCleaner.execute();
+        Objects.requireNonNull(redisTemplate.getConnectionFactory()).getConnection().serverCommands().flushAll();
+    }
+
+    @DisplayName("쿠폰 발급 요청이 있는 경우, 쿠폰 발급 스케줄러가 쿠폰 발급을 처리한다.")
+    @Test
+    void issueCouponScheduler() {
+        // given
+        User user = userRepository.save(UserFixture.USER());
+        LocalDateTime startDate = LocalDateTime.now();
+        LocalDateTime endDate = startDate.plusWeeks(1);
+        Coupon coupon = couponRepository.save(CouponFixture.create(CouponDiscountType.RATE, 10, startDate, endDate, 10));
+
+        CouponIssueParam param = new CouponIssueParam(user.getId(), coupon.getId());
+        couponIssueManager.publish(param);
+
+        Awaitility
+                .await()
+                .atMost(5, TimeUnit.SECONDS)
+                .pollInterval(1, TimeUnit.SECONDS)
+                .until(() -> issuedCouponRepository.existsByUserIdAndCoupon(user.getId(), coupon), equalTo(true));
+
+        assertThat(redisTemplate.opsForSet().isMember(ISSUED_COUPONS_KEY, param)).isTrue();
+        assertThat(redisTemplate.opsForZSet().size(COUPON_ISSUE_QUEUE_KEY)).isZero();
+    }
+
+    @DisplayName("이미 발급된 이력이 있는 경우, 쿠폰 발급 스케줄러가 쿠폰 발급 처리를 하지 않는다.")
+    @Test
+    void issueCouponScheduler_withAlreadyIssuedCoupon() {
+        // given
+        User user = userRepository.save(UserFixture.USER());
+        LocalDateTime startDate = LocalDateTime.now();
+        LocalDateTime endDate = startDate.plusWeeks(1);
+        Coupon coupon = couponRepository.save(CouponFixture.create(CouponDiscountType.RATE, 10, startDate, endDate, 10));
+
+        CouponIssueParam param = new CouponIssueParam(user.getId(), coupon.getId());
+        couponIssueManager.publish(param);
+
+        Awaitility
+                .await()
+                .atMost(5, TimeUnit.SECONDS)
+                .pollInterval(1, TimeUnit.SECONDS)
+                .until(() -> issuedCouponRepository.existsByUserIdAndCoupon(user.getId(), coupon), equalTo(true));
+
+        assertThat(redisTemplate.opsForSet().isMember(ISSUED_COUPONS_KEY, param)).isTrue();
+        assertThat(redisTemplate.opsForSet().size(ISSUED_COUPONS_KEY)).isOne();
+        assertThat(redisTemplate.opsForZSet().size(COUPON_ISSUE_QUEUE_KEY)).isZero();
+
+        couponIssueManager.publish(param);
+
+        assertThatCode(() -> Awaitility
+                .await()
+                .atMost(5, TimeUnit.SECONDS)
+                .pollInterval(1, TimeUnit.SECONDS)
+                .until(() -> redisTemplate.opsForZSet().size(COUPON_ISSUE_QUEUE_KEY), equalTo(0L)))
+                .doesNotThrowAnyException();
+
+        assertThat(redisTemplate.opsForSet().isMember(ISSUED_COUPONS_KEY, param)).isTrue();
+        assertThat(redisTemplate.opsForSet().size(ISSUED_COUPONS_KEY)).isOne();
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -15,3 +15,10 @@ logging:
   pattern:
     console: "%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr(%5p) %clr(${PID:- }){magenta} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n%wEx"
     file: "%d{yyyy-MM-dd HH:mm:ss.SSS} %5p ${PID:- } [%15.15t] %-40.40logger{39} : %m%n%wEx"
+
+schedules:
+  cron:
+    coupon:
+      issue: "*/1 * * * * *"
+  batch:
+    coupon-issue-size: 10


### PR DESCRIPTION
##  PR 설명

>[STEP-14] Requirements
> [이커머스] 선착순 쿠폰발급 기능에 대해 Redis 기반의 설계를 진행하고, 적절하게 동작할 수 있도록 쿠폰 발급 로직을 개선해 제출

위 요구사항에 따라 다음과 같은 세부 작업이 포함되어 있습니다.

- [x] Redis 기반의 선착순 쿠폰 발급 기능 구현 ([88646d1](https://github.com/taekwon-dev/hhplus-ecommerce/pull/12/commits/88646d185c7d7c07339471c230d50f725c5c6451)) 

## Note

- [Awaitility](https://github.com/awaitility/awaitility) 을 활용하여 스케줄러 테스트 진행 (아래 참고)
- 
  ```java
  Awaitility
      .await()
      .atMost(5, TimeUnit.SECONDS) // 최대 5초 까지 대기 (이 안에 아래 조건 만족 못하면 테스트 실패)
      .pollInterval(1, TimeUnit.SECONDS) // 1초 단위로 아래 조건이 성립하는지 체크
      .untilAsserted(() -> assertThat(issuedCouponJpaRepository.count()).isEqualTo(10)); // 최초 한 번 검증 통과 시 테스트 통과
  ```

## 리뷰 포인트

- 질문: Scheduler 에서 Redis 쿠폰 발급 요청을 가져올 때 Batch 사이즈 선택 근거는 어떤 식으로 마련할 수 있을까요? 
- 전반적인 구현 내용에 대해 PR Review 부탁드리고 싶습니다 🙏